### PR TITLE
video4linux Channel Switching Fix

### DIFF
--- a/src/capture/capture_api_video4linux.cpp
+++ b/src/capture/capture_api_video4linux.cpp
@@ -60,7 +60,7 @@ static capture_pixel_format_e CAPTURE_PIXEL_FORMAT = capture_pixel_format_e::rgb
 // The latest frame we've received from the capture device.
 static captured_frame_s FRAME_BUFFER;
 
-// The signal used to hault the capture thread before the handle is released.
+// The signal used to halt the capture thread before the handle is released.
 // Set to !0 to exit the thread and set back to 0 when thread exits.
 static i32 CAPTURE_THREAD_EXIT_REQUESTED = 0;
 

--- a/src/capture/capture_api_video4linux.cpp
+++ b/src/capture/capture_api_video4linux.cpp
@@ -389,6 +389,13 @@ static bool stream_on(void)
     return true;
 }
 
+// Returns true if the given v4l2 capabilities match a vision device
+static bool is_vision_caps(v4l2_capability* card_caps) 
+{
+    return strcmp((const char*)card_caps->driver, "Vision") == 0 && // Verify that card is using "Vision" driver
+        strcmp((const char*)card_caps->card, "Vision Control") != 0; // Verify that card is not "Vision Control" device
+}
+
 bool capture_api_video4linux_s::unqueue_capture_buffers(void)
 {
     // Tell the capture device we want it to use capture buffers we've allocated.
@@ -705,7 +712,7 @@ bool capture_api_video4linux_s::initialize_hardware(void)
 {
     // Open the capture device.
     /// TODO: Query for the correct video channel rather than hardcoding /dev/video0.
-    if ((CAPTURE_HANDLE = open((std::string("/dev/video") + std::to_string(INPUT_CHANNEL_IDX + 1)).c_str(), O_RDWR)) < 0)
+    if ((CAPTURE_HANDLE = open((std::string("/dev/video") + std::to_string(INPUT_CHANNEL_IDX)).c_str(), O_RDWR)) < 0)
     {
         NBENE(("Failed to open the capture device."));
 
@@ -911,10 +918,28 @@ std::string capture_api_video4linux_s::get_device_firmware_version(void) const
     return "Unknown";
 }
 
+
 int capture_api_video4linux_s::get_device_maximum_input_count(void) const
 {
-    // For now, we only support one input channel.
-    return 1;
+    std::string video_device_prefix = "/dev/video";
+    int total_devices = 0;
+
+    for (int i = 0; i < 64; i++) 
+    {
+        v4l2_capability card_caps; 
+
+        int f = open((video_device_prefix + std::to_string(i)).c_str(), O_RDONLY);
+        
+        if (f < 0)
+            continue;
+
+        if (ioctl(f, VIDIOC_QUERYCAP, &card_caps) >= 0 && is_vision_caps(&card_caps))
+            total_devices++;
+
+        close(f);
+    }
+    
+    return total_devices;
 }
 
 video_signal_parameters_s capture_api_video4linux_s::get_video_signal_parameters(void) const

--- a/src/capture/capture_api_video4linux.h
+++ b/src/capture/capture_api_video4linux.h
@@ -45,8 +45,9 @@ struct capture_api_video4linux_s : public capture_api_s
     bool reset_missed_frames_count(void) override;
     bool set_video_signal_parameters(const video_signal_parameters_s &p) override;
 
-    /// TODO: Properly implement these.
-    bool set_input_channel(const unsigned idx) override             { (void)idx; return false;   }
+    bool set_input_channel(const unsigned idx) override;
+
+    /// TODO: Properly implement this.
     bool set_pixel_format(const capture_pixel_format_e pf) override { (void)pf; return false;    }
 
     /// TODO: Does the Vision API allow you to query these?

--- a/src/capture/capture_api_video4linux.h
+++ b/src/capture/capture_api_video4linux.h
@@ -45,7 +45,7 @@ struct capture_api_video4linux_s : public capture_api_s
     bool reset_missed_frames_count(void) override;
     bool set_video_signal_parameters(const video_signal_parameters_s &p) override;
 
-    bool set_input_channel(const unsigned idx) override;
+    bool set_input_channel(const unsigned idx) override { (void)idx; return false; }
 
     /// TODO: Properly implement this.
     bool set_pixel_format(const capture_pixel_format_e pf) override { (void)pf; return false;    }

--- a/src/capture/capture_api_video4linux.h
+++ b/src/capture/capture_api_video4linux.h
@@ -45,9 +45,8 @@ struct capture_api_video4linux_s : public capture_api_s
     bool reset_missed_frames_count(void) override;
     bool set_video_signal_parameters(const video_signal_parameters_s &p) override;
 
+    /// TODO: Properly implement these.
     bool set_input_channel(const unsigned idx) override { (void)idx; return false; }
-
-    /// TODO: Properly implement this.
     bool set_pixel_format(const capture_pixel_format_e pf) override { (void)pf; return false;    }
 
     /// TODO: Does the Vision API allow you to query these?


### PR DESCRIPTION
This branch adds video4linux device (channel) switching functionality. Some of the code might be a bit unintuitive as `capture_function` needs to halt before `release` is called. Everything seems to work when tested with a Datapath VisionRGB-E2S, but code revisions and suggestions would be appreciated.