### PR TITLE
Fix frame buffer function that causes compile to fail.

### DIFF
--- a/src/scaler/scaler.cpp
+++ b/src/scaler/scaler.cpp
@@ -296,7 +296,7 @@ void s_scaler_nearest(SCALER_FUNC_PARAMS)
     #else
         double deltaW = (srcResolution.w / double(dstResolution.w));
         double deltaH = (srcResolution.h / double(dstResolution.h));
-        u8 *const dst = FRAME_BUFFER.pixels.ptr();
+        u8 *const dst = FRAME_BUFFER.pixels.data();
 
         for (uint y = 0; y < dstResolution.h; y++)
         {


### PR DESCRIPTION
This is a fix for issue #25  for scale.cpp having an out of date call.