### PR TITLE
Fix sVWVideoTimings error when including rgb133v4l2.h

### DIFF
--- a/src/capture/vision_v4l/capture_vision_v4l.cpp
+++ b/src/capture/vision_v4l/capture_vision_v4l.cpp
@@ -30,6 +30,7 @@
 #include "common/propagate/vcs_event.h"
 
 #define INCLUDE_VISION
+#include <visionrgb/include/rgb133control.h>
 #include <visionrgb/include/rgb133v4l2.h>
 
 // The input channel (/dev/videoX device) we're currently capturing from.

--- a/src/capture/vision_v4l/ic_v4l_video_parameters.cpp
+++ b/src/capture/vision_v4l/ic_v4l_video_parameters.cpp
@@ -18,6 +18,7 @@
 #include "capture/vision_v4l/ic_v4l_video_parameters.h"
 
 #define INCLUDE_VISION
+#include <visionrgb/include/rgb133control.h>
 #include <visionrgb/include/rgb133v4l2.h>
 
 ic_v4l_device_controls_c::ic_v4l_device_controls_c(const int v4lDeviceFileHandle) :

--- a/src/capture/vision_v4l/input_channel_v4l.cpp
+++ b/src/capture/vision_v4l/input_channel_v4l.cpp
@@ -18,6 +18,7 @@
 #include "capture/vision_v4l/ic_v4l_video_parameters.h"
 
 #define INCLUDE_VISION
+#include <visionrgb/include/rgb133control.h>
 #include <visionrgb/include/rgb133v4l2.h>
 
 // We'll persist the resolution and refresh rate, so that when a new video mode


### PR DESCRIPTION
When compiling with the latest Vision driver (7.22.0.16046) I get an error related to type definitions:

```
In file included from src/capture/vision_v4l/capture_vision_v4l.cpp:33:
../sdk/visionrgb/include/rgb133v4l2.h:144:4: error: ‘sVWVideoTimings’ does not name a type; did you mean ‘_srgb133VideoTimings’?
  144 |    sVWVideoTimings  VideoTimings;
      |    ^~~~~~~~~~~~~~~
      |    _srgb133VideoTimings
src/capture/vision_v4l/capture_vision_v4l.cpp: In function ‘bool kc_initialize_device()’:
src/capture/vision_v4l/capture_vision_v4l.cpp:188:5: warning: label ‘fail’ defined but not used [-Wunused-label]
  188 |     fail:
      |     ^~~~
make: *** [Makefile:2519: generated_files/capture_vision_v4l.o] Error 1

```

Including the `rgb133control.h` file before including `rgb133v4l2.h` fixes this. The SDK example application "Vision" does this in the `VWInputProperties.h` file for its includes